### PR TITLE
Remove the closure in routes.php so that route caching can work

### DIFF
--- a/src/Controllers/TestController.php
+++ b/src/Controllers/TestController.php
@@ -1,0 +1,18 @@
+<?php
+namespace ProcessMaker\i18next\Controllers;
+
+use Illuminate\Routing\Controller as BaseController;
+
+class TestController extends BaseController
+{
+    /**
+     * @param string $lang
+     * @param string $namespace
+     */
+    public function test()
+    {
+        return view('i18next::test', [
+            'lang' => request()->get('lang', app()->getLocale())
+        ]);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,9 +1,5 @@
 <?php
 
-Route::get('/i18next/test', function() {
-    return view('i18next::test', [
-        'lang' => request()->get('lang', App::getLocale())
-    ]);
-});
+Route::get('/i18next/test', 'ProcessMaker\i18next\Controllers\TestController@test');
 
 Route::get('/i18next/fetch/{lang}/{namespace?}', 'ProcessMaker\i18next\Controllers\FetchController@fetch');


### PR DESCRIPTION
My only problem with this little package is that route caching doesn't work with it, because of the /i18next/test route. This pull request creates a TestController and uses that instead of the closure.